### PR TITLE
Simple typo fix

### DIFF
--- a/lib/ansible/modules/network/wakeonlan.py
+++ b/lib/ansible/modules/network/wakeonlan.py
@@ -61,7 +61,7 @@ EXAMPLES = '''
 - wakeonlan:
     mac: '00:00:5E:00:53:66'
     broadcast: 192.0.2.23
-  delegate_to: loclahost
+  delegate_to: localhost
 
 - wakeonlan:
     mac: 00:00:5E:00:53:66


### PR DESCRIPTION
I was reading the docs of the module and spotted a typo.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
wakeonlan

##### ANSIBLE VERSION
N/A

##### SUMMARY
Typo fix
